### PR TITLE
Update zen-observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-runtime": "^6.22.0",
     "envify": "^4.0.0",
     "symbol-observable": "^1.0.4",
-    "zen-observable": "^0.5.2"
+    "zen-observable": "^0.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
This version of zen-observable fixes [an issue](https://github.com/zenparsing/zen-observable/issues/37) we're seeing with your build system. We use [Yarn](https://yarnpkg.com/en/), which unfortunately has [an issue](https://github.com/yarnpkg/yarn/issues/2364#issuecomment-345349851) with pulling the correct version in spite of the specific version range. If you'd be willing to update this and publish, it'd be much appreciated! If not, we'll use our fork of this until we can fix the Yarn issue.